### PR TITLE
Add blocked field to projects API endpoint

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "id": "f879df78-af6d-44cb-987e-ac54c2755e71",
   "name": "Thyme BC API Extension",
   "publisher": "KnowAll",
-  "version": "1.9.2.0",
+  "version": "1.9.3.0",
   "brief": "Custom API endpoints for Thyme time tracking app",
   "description": "Exposes Projects, Job Tasks, Time Sheets, Resources, and Time Entries with additional fields not available in the standard BC API v2.0",
   "privacyStatement": "https://knowall.ai/privacy",

--- a/src/api/ThymeProjectsAPI.Page.al
+++ b/src/api/ThymeProjectsAPI.Page.al
@@ -52,6 +52,10 @@ page 50100 "Thyme Projects API"
                 {
                     Caption = 'Status';
                 }
+                field(blocked; Rec.Blocked)
+                {
+                    Caption = 'Blocked';
+                }
                 field(startingDate; Rec."Starting Date")
                 {
                     Caption = 'Starting Date';


### PR DESCRIPTION
## Summary

- Adds the `blocked` field (`Rec.Blocked`) to the Thyme Projects API page, exposing the enum values (`' '`, `Posting`, `All`)
- Bumps extension version from `1.9.2.0` → `1.9.3.0`

This allows the Thyme web app to filter out archived/blocked projects from project lists, timer, and time entry dropdowns.

Closes #30

## Test plan

- [x] Deploy to BC sandbox
- [x] Call `/api/knowall/thyme/v1.0/companies({id})/projects` and verify the `blocked` field is present in the response
- [x] Confirm blocked projects return `Posting` or `All` values as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)