### PR TITLE
Add CODEOWNERS to require @BenGWeeks approval on PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# Code owners for the Thyme BC Extension repository.
+#
+# Every file in this repo requires review from @BenGWeeks before merge,
+# enforced by branch protection on main with require_code_owner_reviews enabled.
+#
+# Format: <pattern> <owner...>
+# Order matters: later matching rules override earlier ones.
+# See https://docs.github.com/en/repositories/managing-your-repositories-settings-and-security/customizing-your-repository/about-code-owners
+
+*       @BenGWeeks


### PR DESCRIPTION
## Summary

Adds `.github/CODEOWNERS` with a single rule:

```
*       @BenGWeeks
```

This designates @BenGWeeks as the code owner for every file in the repository. Combined with branch protection on `main` configured with `require_code_owner_reviews: true`, this means every PR must be approved by @BenGWeeks before it can be merged.

## Why this is needed

Without CODEOWNERS, "require 1 approval" branch protection is satisfied by *any* collaborator with write access. The current write-permission collaborators are @BenGWeeks, @EdiWeeks, and @akash2017sky — meaning @EdiWeeks and @akash2017sky could approve each other's PRs without the repository owner ever reviewing them.

CODEOWNERS makes the rule specific: an approval only counts towards merge-readiness if it comes from a code owner.

## How this interacts with PR authors

GitHub does not allow a PR author to approve their own PR. With @BenGWeeks as the sole code owner:

- **Other contributors' PRs** — must be approved by @BenGWeeks before merging.
- **@BenGWeeks's own PRs** — can be merged via admin bypass (branch protection will be configured with `enforce_admins: false`), since otherwise they would be unmergeable.

This trade-off can be revisited later by adding a second code owner if delegation becomes useful.

## Follow-ups

- Apply branch protection on `main` with `require_code_owner_reviews: true` (separate, settings-only operation via `gh api`)
- Documented in `docs/DEPLOYMENT.adoc` (PR #32)

## Test plan

- [ ] After merge and branch protection rollout, open a test PR with a trivial change and confirm the merge button is blocked until @BenGWeeks approves
- [ ] Confirm the PR's *Reviewers* sidebar automatically requests @BenGWeeks once CODEOWNERS is on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)