### PR TITLE
fix: make POST /timeSheets create a usable time sheet header

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "id": "f879df78-af6d-44cb-987e-ac54c2755e71",
   "name": "Thyme BC API Extension",
   "publisher": "KnowAll",
-  "version": "1.9.3.0",
+  "version": "1.10.0.0",
   "brief": "Custom API endpoints for Thyme time tracking app",
   "description": "Exposes Projects, Job Tasks, Time Sheets, Resources, and Time Entries with additional fields not available in the standard BC API v2.0",
   "privacyStatement": "https://knowall.ai/privacy",

--- a/docs/SOLUTION_DESIGN.adoc
+++ b/docs/SOLUTION_DESIGN.adoc
@@ -164,6 +164,20 @@ Maps to the BC `Time Sheet Header` table (table 950).
 | lastModifiedDateTime | SystemModifiedAt | For sync
 |===
 
+==== Creating a Time Sheet
+
+`POST /timeSheets` with `resourceNo` and `startingDate` creates a time sheet header
+equivalent to the one BC's *Create Time Sheets* batch job produces. The extension
+supplies the rest on insert:
+
+* `number` from the **Time Sheet Nos.** series on Resources Setup
+* `endingDate` as `startingDate + 6` days
+* `ownerUserId` and `approverUserId` from the resource card
+
+The insert is rejected if the resource does not have **Use Time Sheet** enabled, if no
+time sheet number series is configured, or if the period overlaps an existing time
+sheet for that resource.
+
 ==== Bound Actions
 
 The Time Sheets API supports the following bound actions for approval workflow:

--- a/docs/TROUBLESHOOTING.adoc
+++ b/docs/TROUBLESHOOTING.adoc
@@ -75,6 +75,15 @@
 
 | Extension upload fails with generic error, no details in API
 | *Placeholder app ID*: If your `app.json` has a placeholder ID like `"id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"`, BC will reject the upload. Generate a proper unique GUID using `uuidgen` (Linux/Mac) or `[guid]::NewGuid()` (PowerShell) and replace the placeholder.
+
+| `POST /timeSheets` returns a record with a blank `number` and `endingDate` of `0001-01-01`
+| Extension version is older than 1.10.0.0, which had no insert logic on the Time Sheets API - the record was written straight to the `Time Sheet Header` table without the number series or week end date, leaving an unusable row. Upgrade the extension, then delete the blank-numbered rows in BC (Time Sheets list) and recreate them. Thyme shows "No Timesheet Available" for the affected weeks.
+
+| `POST /timeSheets` fails with "Time Sheet Nos. must have a value in Resources Setup"
+| The company has no time sheet number series. In BC go to *Resources Setup* → set *Time Sheet Nos.* to a number series (create one under *No. Series* if needed), then retry.
+
+| `POST /timeSheets` fails with "A time sheet already exists for resource ... covering ..."
+| A time sheet already covers that period. Either the week was already created, or the `startingDate` is not aligned to the resource's week boundary and overlaps the neighbouring sheet. Check the existing sheets with `GET /timeSheets?$filter=resourceNo eq 'R0010'` and use a starting date that matches their weekday.
 |===
 
 == Getting Help

--- a/src/api/ThymeTimeSheetAPI.Page.al
+++ b/src/api/ThymeTimeSheetAPI.Page.al
@@ -78,6 +78,19 @@ page 50102 "Thyme Time Sheet API"
     }
 
     /// <summary>
+    /// Applies the same setup as BC's "Create Time Sheets" batch job before inserting,
+    /// so POST /timeSheets produces a usable header instead of one with a blank No.
+    /// </summary>
+    trigger OnInsertRecord(BelowxRec: Boolean): Boolean
+    var
+        ThymeActions: Codeunit "Thyme Time Sheet Actions";
+    begin
+        ThymeActions.InitTimeSheetFromApi(Rec);
+        Rec.Insert(true);
+        exit(false);
+    end;
+
+    /// <summary>
     /// Submits the time sheet for approval.
     /// POST /timeSheets({id})/Microsoft.NAV.submit
     /// </summary>

--- a/src/codeunit/ThymeTimeSheetActions.Codeunit.al
+++ b/src/codeunit/ThymeTimeSheetActions.Codeunit.al
@@ -4,6 +4,56 @@
 /// </summary>
 codeunit 50100 "Thyme Time Sheet Actions"
 {
+    var
+        TimeSheetOverlapErr: Label 'A time sheet already exists for resource %1 covering %2. Overlapping time sheets are not allowed.', Comment = '%1 = resource number, %2 = starting date';
+
+    /// <summary>
+    /// Prepares a new Time Sheet Header created through the API so that it matches
+    /// what BC's "Create Time Sheets" batch job would have produced.
+    ///
+    /// A plain API insert leaves "No." blank (the number series is only applied by the
+    /// batch job) and "Ending Date" as 0D, which produces an unusable header. This fills
+    /// in the number, the week end date and the owner/approver from the resource card.
+    /// </summary>
+    procedure InitTimeSheetFromApi(var TimeSheetHeader: Record "Time Sheet Header")
+    var
+        Resource: Record Resource;
+        ResourcesSetup: Record "Resources Setup";
+        ExistingTimeSheet: Record "Time Sheet Header";
+        NoSeries: Codeunit "No. Series";
+    begin
+        TimeSheetHeader.TestField("Resource No.");
+        TimeSheetHeader.TestField("Starting Date");
+
+        Resource.Get(TimeSheetHeader."Resource No.");
+        Resource.TestField("Use Time Sheet");
+
+        if TimeSheetHeader."Ending Date" <= TimeSheetHeader."Starting Date" then
+            TimeSheetHeader."Ending Date" := TimeSheetHeader."Starting Date" + 6;
+
+        // Reject a period that overlaps an existing sheet. This catches both a duplicate
+        // week and a starting date that is not aligned to the resource's week boundary.
+        ExistingTimeSheet.SetRange("Resource No.", TimeSheetHeader."Resource No.");
+        ExistingTimeSheet.SetFilter("Ending Date", '>=%1', TimeSheetHeader."Starting Date");
+        ExistingTimeSheet.SetFilter("Starting Date", '<=%1', TimeSheetHeader."Ending Date");
+        if not ExistingTimeSheet.IsEmpty() then
+            Error(TimeSheetOverlapErr, TimeSheetHeader."Resource No.", TimeSheetHeader."Starting Date");
+
+        if TimeSheetHeader."No." = '' then begin
+            ResourcesSetup.Get();
+            ResourcesSetup.TestField("Time Sheet Nos.");
+            TimeSheetHeader."No." := NoSeries.GetNextNo(ResourcesSetup."Time Sheet Nos.", TimeSheetHeader."Starting Date");
+        end;
+
+        if TimeSheetHeader."Owner User ID" = '' then
+            TimeSheetHeader."Owner User ID" := Resource."Time Sheet Owner User ID";
+        if TimeSheetHeader."Approver User ID" = '' then
+            TimeSheetHeader."Approver User ID" := Resource."Time Sheet Approver User ID";
+
+        TimeSheetHeader.TestField("Owner User ID");
+        TimeSheetHeader.TestField("Approver User ID");
+    end;
+
     /// <summary>
     /// Submits a time sheet for approval by submitting all open lines.
     /// </summary>

--- a/src/codeunit/ThymeTimeSheetActions.Codeunit.al
+++ b/src/codeunit/ThymeTimeSheetActions.Codeunit.al
@@ -28,15 +28,19 @@ codeunit 50100 "Thyme Time Sheet Actions"
         Resource.Get(TimeSheetHeader."Resource No.");
         Resource.TestField("Use Time Sheet");
 
-        if TimeSheetHeader."Ending Date" <= TimeSheetHeader."Starting Date" then
-            TimeSheetHeader."Ending Date" := TimeSheetHeader."Starting Date" + 6;
+        // Always a one week period, as the batch job produces. Any endingDate supplied by
+        // the caller is overwritten rather than honoured, so the period cannot drift away
+        // from the contract and undermine the overlap check below.
+        TimeSheetHeader."Ending Date" := TimeSheetHeader."Starting Date" + 6;
 
         // Reject a period that overlaps an existing sheet. This catches both a duplicate
         // week and a starting date that is not aligned to the resource's week boundary.
+        // Lock first so concurrent POSTs for the same period cannot both pass the check.
+        ExistingTimeSheet.LockTable();
         ExistingTimeSheet.SetRange("Resource No.", TimeSheetHeader."Resource No.");
         ExistingTimeSheet.SetFilter("Ending Date", '>=%1', TimeSheetHeader."Starting Date");
         ExistingTimeSheet.SetFilter("Starting Date", '<=%1', TimeSheetHeader."Ending Date");
-        if not ExistingTimeSheet.IsEmpty() then
+        if ExistingTimeSheet.FindFirst() then
             Error(TimeSheetOverlapErr, TimeSheetHeader."Resource No.", TimeSheetHeader."Starting Date");
 
         if TimeSheetHeader."No." = '' then begin


### PR DESCRIPTION
## Problem

`POST /timeSheets` on the Thyme custom API produced a broken record: blank `number` and `endingDate` of `0001-01-01`.

`ThymeTimeSheetAPI.Page.al` had no insert logic, so the platform wrote a `Time Sheet Header` straight to the table. BC only assigns the number (from the **Time Sheet Nos.** series on Resources Setup) and the ending date inside the *Create Time Sheets* batch job — never on a plain insert. The resulting row is unusable, and Thyme still shows **No Timesheet Available** for that week.

This is why Thyme's *Plan → create timesheets for resources* feature has never worked. Found while trying to create a missing week for KnowAll AI SAS de CV.

## Fix

`OnInsertRecord` on the API page now calls a new `InitTimeSheetFromApi` procedure that applies the same setup the batch job does:

- `number` from the **Time Sheet Nos.** series on Resources Setup
- `endingDate` = `startingDate + 6`
- `ownerUserId` / `approverUserId` from the resource card

It rejects the insert when:

- the resource does not have **Use Time Sheet** enabled
- no time sheet number series is configured
- the period overlaps an existing sheet for that resource (catches both a duplicate week and a `startingDate` misaligned to the week boundary)

## Also

- Version bumped to `1.10.0.0` so BC will reinstall
- `SOLUTION_DESIGN.adoc` documents the create contract
- Three new `TROUBLESHOOTING.adoc` entries, including how to clean up blank-numbered rows left by the old behaviour

## Verification

CI compile is the check here — there is no local AL toolchain on this machine. After merge and deploy I'll create the six missing SAS de CV weeks (29 Jun – 9 Aug 2026) through the API and confirm the numbers and end dates come back populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AneqYn5b3TRzCtmzr4AjLo